### PR TITLE
Generic API Error Handling

### DIFF
--- a/internal/http_executor/http.go
+++ b/internal/http_executor/http.go
@@ -112,7 +112,7 @@ func (c *Client) handleErrorResponse(resp *http.Response) error {
 		return fmt.Errorf("failed to format error response body: %v", err)
 	}
 
-	return fmt.Errorf("%v\n", string(errFormatted))
+	return fmt.Errorf("%s", errFormatted)
 }
 
 // addQueryParameters adds the parameters in the struct params as URL query parameters to s.

--- a/internal/http_executor/http_test.go
+++ b/internal/http_executor/http_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -126,8 +127,12 @@ func TestExecuteRequest_ServerErrorPOST(t *testing.T) {
 		t.Fatalf("Expected an error, got nil")
 	}
 
-	expectedErrorMessage := "processing response failed: HTTP 500: internal server error"
-	if err.Error() != expectedErrorMessage {
+	expectedErrorMessage := `processing response failed: {
+	"message": "internal server error"
+}`
+
+	// Remove all whitespace when comparing the errors
+	if strings.Join(strings.Fields(err.Error()), "") != strings.Join(strings.Fields(expectedErrorMessage), "") {
 		t.Errorf("Expected error message '%s', got '%s'", expectedErrorMessage, err.Error())
 	}
 }


### PR DESCRIPTION
We can return them in the collapsed view too if that is better. Right now, the new lines and whitespace are formatted in. Here is an example using the swap example file:

```
Failed to get swap data: processing response failed: {
    "description": "Not enough 0x853d955acef822db058eb8505911ed77f175b99e balance. Amount: 1000000000000000000. Balance: 0",
    "error": "Bad Request",
    "meta": [
        {
            "type": "fromTokenAddress",
            "value": "0x853d955acef822db058eb8505911ed77f175b99e"
        },
        {
            "type": "amount",
            "value": "1000000000000000000"
        },
        {
            "type": "fromTokenBalance",
            "value": "0"
        }
    ],
    "requestId": "8b78c4b7-e9e1-46e2-84fa-457c26c1c275",
    "statusCode": 400
}
```