### PR TITLE
Fixing the exclusive resolver type on usion quote responses 

### DIFF
--- a/sdk-clients/fusion/fusion_types_extended.go
+++ b/sdk-clients/fusion/fusion_types_extended.go
@@ -10,10 +10,10 @@ import (
 
 type GetQuoteOutputFixed struct {
 	// FeeToken Destination token address
-	FeeToken        string            `json:"feeToken"`
-	FromTokenAmount string            `json:"fromTokenAmount"`
-	Presets         QuotePresetsClass `json:"presets"`
-	Prices          TokenPairValue    `json:"prices"`
+	FeeToken        string                 `json:"feeToken"`
+	FromTokenAmount string                 `json:"fromTokenAmount"`
+	Presets         QuotePresetsClassFixed `json:"presets"`
+	Prices          TokenPairValue         `json:"prices"`
 
 	// QuoteId Current generated quote id, should be passed with order
 	QuoteId string `json:"quoteId"` // TODO This field is marked as "object" instead of "string" in the swagger file. This is an easy fix from the Fusion team
@@ -231,4 +231,29 @@ type QuoterControllerGetQuoteParamsFixed struct {
 
 	// Permit permit, user approval sign
 	Permit string `url:"permit,omitempty" json:"permit,omitempty"`
+}
+
+// PresetClassFixed defines model for PresetClass.
+type PresetClassFixed struct {
+	AllowMultipleFills bool                `json:"allowMultipleFills"`
+	AllowPartialFills  bool                `json:"allowPartialFills"`
+	AuctionDuration    float32             `json:"auctionDuration"`
+	AuctionEndAmount   string              `json:"auctionEndAmount"`
+	AuctionStartAmount string              `json:"auctionStartAmount"`
+	BankFee            string              `json:"bankFee"`
+	EstP               float32             `json:"estP"`
+	ExclusiveResolver  string              `json:"exclusiveResolver"` // This was changed to a string from a map[string]interface{}
+	GasCost            GasCostConfigClass  `json:"gasCost"`
+	InitialRateBump    float32             `json:"initialRateBump"`
+	Points             []AuctionPointClass `json:"points"`
+	StartAuctionIn     float32             `json:"startAuctionIn"`
+	TokenFee           string              `json:"tokenFee"`
+}
+
+// QuotePresetsClassFixed defines model for QuotePresetsClass.
+type QuotePresetsClassFixed struct {
+	Custom *PresetClassFixed `json:"custom,omitempty"`
+	Fast   PresetClassFixed  `json:"fast"`
+	Medium PresetClassFixed  `json:"medium"`
+	Slow   PresetClassFixed  `json:"slow"`
 }

--- a/sdk-clients/fusion/order.go
+++ b/sdk-clients/fusion/order.go
@@ -160,7 +160,7 @@ func BigIntFromString(s string) (*big.Int, error) {
 	return bigInt, nil
 }
 
-func getPreset(presets QuotePresetsClass, presetType GetQuoteOutputRecommendedPreset) (*PresetClass, error) {
+func getPreset(presets QuotePresetsClassFixed, presetType GetQuoteOutputRecommendedPreset) (*PresetClassFixed, error) {
 	switch presetType {
 	case Custom:
 		if presets.Custom == nil {
@@ -184,7 +184,7 @@ func CalcAuctionStartTime(startAuctionIn uint32, additionalWaitPeriod uint32) ui
 	return uint32(currentTime) + additionalWaitPeriod + startAuctionIn
 }
 
-func CreateAuctionDetails(preset *PresetClass, additionalWaitPeriod float32) (*AuctionDetails, error) {
+func CreateAuctionDetails(preset *PresetClassFixed, additionalWaitPeriod float32) (*AuctionDetails, error) {
 	pointsFixed := make([]AuctionPointClassFixed, 0)
 	for _, point := range preset.Points {
 		pointsFixed = append(pointsFixed, AuctionPointClassFixed{

--- a/sdk-clients/fusion/order_test.go
+++ b/sdk-clients/fusion/order_test.go
@@ -129,7 +129,7 @@ func TestCreateFusionOrderData(t *testing.T) {
 }
 
 func TestGetPreset(t *testing.T) {
-	customPreset := &PresetClass{
+	customPreset := &PresetClassFixed{
 		AllowMultipleFills: true,
 		AllowPartialFills:  true,
 		AuctionDuration:    10.0,
@@ -137,7 +137,7 @@ func TestGetPreset(t *testing.T) {
 		AuctionStartAmount: "500",
 		BankFee:            "5",
 		EstP:               0.1,
-		ExclusiveResolver:  map[string]interface{}{"resolver": "value"},
+		ExclusiveResolver:  "resolver",
 		GasCost: GasCostConfigClass{
 			GasBumpEstimate:  1.0,
 			GasPriceEstimate: "100",
@@ -150,7 +150,7 @@ func TestGetPreset(t *testing.T) {
 		TokenFee:       "1",
 	}
 
-	fastPreset := PresetClass{
+	fastPreset := PresetClassFixed{
 		AllowMultipleFills: false,
 		AllowPartialFills:  false,
 		AuctionDuration:    20.0,
@@ -158,7 +158,7 @@ func TestGetPreset(t *testing.T) {
 		AuctionStartAmount: "1000",
 		BankFee:            "10",
 		EstP:               0.2,
-		ExclusiveResolver:  map[string]interface{}{"resolver": "value"},
+		ExclusiveResolver:  "resolver",
 		GasCost: GasCostConfigClass{
 			GasBumpEstimate:  2.0,
 			GasPriceEstimate: "200",
@@ -171,7 +171,7 @@ func TestGetPreset(t *testing.T) {
 		TokenFee:       "2",
 	}
 
-	mediumPreset := PresetClass{
+	mediumPreset := PresetClassFixed{
 		AllowMultipleFills: true,
 		AllowPartialFills:  false,
 		AuctionDuration:    30.0,
@@ -179,7 +179,7 @@ func TestGetPreset(t *testing.T) {
 		AuctionStartAmount: "1500",
 		BankFee:            "15",
 		EstP:               0.3,
-		ExclusiveResolver:  map[string]interface{}{"resolver": "value"},
+		ExclusiveResolver:  "resolver",
 		GasCost: GasCostConfigClass{
 			GasBumpEstimate:  3.0,
 			GasPriceEstimate: "300",
@@ -192,7 +192,7 @@ func TestGetPreset(t *testing.T) {
 		TokenFee:       "3",
 	}
 
-	slowPreset := PresetClass{
+	slowPreset := PresetClassFixed{
 		AllowMultipleFills: false,
 		AllowPartialFills:  true,
 		AuctionDuration:    40.0,
@@ -200,7 +200,7 @@ func TestGetPreset(t *testing.T) {
 		AuctionStartAmount: "2000",
 		BankFee:            "20",
 		EstP:               0.4,
-		ExclusiveResolver:  map[string]interface{}{"resolver": "value"},
+		ExclusiveResolver:  "resolver",
 		GasCost: GasCostConfigClass{
 			GasBumpEstimate:  4.0,
 			GasPriceEstimate: "400",
@@ -213,7 +213,7 @@ func TestGetPreset(t *testing.T) {
 		TokenFee:       "4",
 	}
 
-	presets := QuotePresetsClass{
+	presets := QuotePresetsClassFixed{
 		Custom: customPreset,
 		Fast:   fastPreset,
 		Medium: mediumPreset,
@@ -223,7 +223,7 @@ func TestGetPreset(t *testing.T) {
 	tests := []struct {
 		name       string
 		presetType GetQuoteOutputRecommendedPreset
-		expected   *PresetClass
+		expected   *PresetClassFixed
 		expectErr  bool
 	}{
 		{
@@ -274,14 +274,14 @@ func TestGetPreset(t *testing.T) {
 func TestCreateAuctionDetails(t *testing.T) {
 	tests := []struct {
 		name                 string
-		preset               *PresetClass
+		preset               *PresetClassFixed
 		additionalWaitPeriod float32
 		expected             *AuctionDetails
 		expectErr            bool
 	}{
 		{
 			name: "Valid Preset",
-			preset: &PresetClass{
+			preset: &PresetClassFixed{
 				AllowMultipleFills: true,
 				AllowPartialFills:  true,
 				AuctionDuration:    60.0,
@@ -289,7 +289,7 @@ func TestCreateAuctionDetails(t *testing.T) {
 				AuctionStartAmount: "500",
 				BankFee:            "5",
 				EstP:               0.1,
-				ExclusiveResolver:  map[string]interface{}{"resolver": "value"},
+				ExclusiveResolver:  "resolver",
 				GasCost: GasCostConfigClass{
 					GasBumpEstimate:  1.0,
 					GasPriceEstimate: "100",
@@ -318,7 +318,7 @@ func TestCreateAuctionDetails(t *testing.T) {
 		},
 		{
 			name: "Invalid Gas Price Estimate",
-			preset: &PresetClass{
+			preset: &PresetClassFixed{
 				AllowMultipleFills: true,
 				AllowPartialFills:  true,
 				AuctionDuration:    60.0,
@@ -326,7 +326,7 @@ func TestCreateAuctionDetails(t *testing.T) {
 				AuctionStartAmount: "500",
 				BankFee:            "5",
 				EstP:               0.1,
-				ExclusiveResolver:  map[string]interface{}{"resolver": "value"},
+				ExclusiveResolver:  "resolver",
 				GasCost: GasCostConfigClass{
 					GasBumpEstimate:  1.0,
 					GasPriceEstimate: "invalid",


### PR DESCRIPTION
- Fixing a parsing error that happened when an exclusive resolver was returned on Fusion quotes

This is a symptom of a larger problem around the code generation and our existing openapi spec files. The root cause will be addressed in a later pass on the SDK