### PR TITLE
Fusion order creations/lookups now improved

### DIFF
--- a/sdk-clients/fusion/examples/get_order/main.go
+++ b/sdk-clients/fusion/examples/get_order/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/1inch/1inch-sdk-go/constants"
+	"github.com/1inch/1inch-sdk-go/sdk-clients/fusion"
+)
+
+var (
+	devPortalToken = os.Getenv("DEV_PORTAL_TOKEN")
+	privateKey     = os.Getenv("WALLET_KEY")
+	chainId        = constants.PolygonChainId
+	orderhash      = "insert_order_hash_here"
+)
+
+func main() {
+	config, err := fusion.NewConfiguration(fusion.ConfigurationParams{
+		ApiUrl:     "https://api.1inch.dev",
+		ApiKey:     devPortalToken,
+		ChainId:    uint64(chainId),
+		PrivateKey: privateKey,
+	})
+	if err != nil {
+		log.Fatalf("failed to create configuration: %v", err)
+	}
+	client, err := fusion.NewClient(config)
+	if err != nil {
+		log.Fatalf("failed to create client: %v", err)
+	}
+	ctx := context.Background()
+
+	response, err := client.GetOrderStatus(ctx, orderhash)
+	if err != nil {
+		log.Fatalf("failed to request: %v", err)
+	}
+
+	output, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		log.Fatalf("Failed to marshal response: %v\n", err)
+	}
+	fmt.Printf("Response: %s\n", string(output))
+}

--- a/sdk-clients/fusion/examples/place_order/main.go
+++ b/sdk-clients/fusion/examples/place_order/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/1inch/1inch-sdk-go/sdk-clients/fusion"
 )
@@ -68,12 +69,27 @@ func main() {
 		Preset:           fusion.Fast,
 	}
 
-	fmt.Println("Placing order")
-	err = client.PlaceOrder(ctx, *response, orderParams, client.Wallet)
+	orderHash, err := client.PlaceOrder(ctx, *response, orderParams, client.Wallet)
 	if err != nil {
-		log.Fatalf("failed to request: %v", err)
+		log.Fatalf("failed to place order: %v", err)
 	}
 
-	// A successful Fusion order submission has no response body
-	fmt.Printf("Success!")
+	fmt.Printf("Order placed! Order hash: %s\n", orderHash)
+	fmt.Println("Monitoring order until it completes...")
+
+	for {
+		select {
+		case <-time.After(1 * time.Second):
+			order, err := client.GetOrderStatus(ctx, orderHash)
+			if err != nil {
+				fmt.Printf("failed to get order from order hash: %v", err)
+				return
+			}
+
+			fmt.Printf("Order status: %s\n", order.Status)
+			if order.Status == "filled" {
+				return
+			}
+		}
+	}
 }

--- a/sdk-clients/fusion/fusion_types_extended.go
+++ b/sdk-clients/fusion/fusion_types_extended.go
@@ -232,3 +232,34 @@ type QuoterControllerGetQuoteParamsFixed struct {
 	// Permit permit, user approval sign
 	Permit string `url:"permit,omitempty" json:"permit,omitempty"`
 }
+
+type OrderResponse struct {
+	ApproximateTakingAmount string  `json:"approximateTakingAmount"`
+	AuctionDuration         int     `json:"auctionDuration"`
+	AuctionStartDate        int64   `json:"auctionStartDate"`
+	CancelTx                *string `json:"cancelTx"`
+	CreatedAt               string  `json:"createdAt"`
+	Extension               string  `json:"extension"`
+	Fills                   []struct {
+		FilledAuctionTakerAmount string `json:"filledAuctionTakerAmount"`
+		FilledMakerAmount        string `json:"filledMakerAmount"`
+		TxHash                   string `json:"txHash"`
+	} `json:"fills"`
+	FromTokenToUsdPrice string `json:"fromTokenToUsdPrice"`
+	InitialRateBump     int    `json:"initialRateBump"`
+	IsNativeCurrency    bool   `json:"isNativeCurrency"`
+	Order               struct {
+		Maker        string `json:"maker"`
+		MakerAsset   string `json:"makerAsset"`
+		MakerTraits  string `json:"makerTraits"`
+		MakingAmount string `json:"makingAmount"`
+		Receiver     string `json:"receiver"`
+		Salt         string `json:"salt"`
+		TakerAsset   string `json:"takerAsset"`
+		TakingAmount string `json:"takingAmount"`
+	} `json:"order"`
+	OrderHash         string                   `json:"orderHash"`
+	Points            []AuctionPointClassFixed `json:"points"`
+	Status            string                   `json:"status"`
+	ToTokenToUsdPrice string                   `json:"toTokenToUsdPrice"`
+}


### PR DESCRIPTION
- Placing Fusion orders now returns the order hash. This can be used for future lookups of the order's status
- GetOrder function implemented to lookup Fusion orders based on their hash