### PR TITLE
Updating Orderbook SDK to use the maker endpoints to get signature data

### DIFF
--- a/sdk-clients/orderbook/api.go
+++ b/sdk-clients/orderbook/api.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/1inch/1inch-sdk-go/common"
 )
@@ -96,6 +97,39 @@ func (api *api) GetOrder(ctx context.Context, params GetOrderParams) (*GetOrderB
 	}
 
 	return NormalizeGetOrderByHashResponse(getOrderByHashResponse)
+}
+
+// GetOrderWithSignature first looks up an order by hash, then does a second request to get the signature data
+func (api *api) GetOrderWithSignature(ctx context.Context, params GetOrderParams) (*OrderExtendedWithSignature, error) {
+
+	// First lookup the order by hash (no signature on this response)
+	order, err := api.GetOrder(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	// For free accounts, this sleep is required to avoid 429 errors
+	if params.SleepBetweenSubrequests {
+		time.Sleep(time.Second)
+	}
+
+	// Second, lookup all orders by that creator (these orders will contain the signature data)
+	allOrdersByCreator, err := api.GetOrdersByCreatorAddress(ctx, GetOrdersByCreatorAddressParams{
+		CreatorAddress: order.OrderMaker,
+	})
+
+	// Filter through the second set of orders to find the signature
+	for _, o := range allOrdersByCreator {
+		if o.OrderHash == params.OrderHash {
+			return &OrderExtendedWithSignature{
+				GetOrderByHashResponse:   order.GetOrderByHashResponse,
+				LimitOrderDataNormalized: order.LimitOrderDataNormalized,
+				Signature:                o.Signature,
+			}, nil
+		}
+	}
+
+	return nil, errors.New("order not found")
 }
 
 // GetAllOrders returns all orders in the Limit Order Protocol

--- a/sdk-clients/orderbook/api.go
+++ b/sdk-clients/orderbook/api.go
@@ -117,6 +117,9 @@ func (api *api) GetOrderWithSignature(ctx context.Context, params GetOrderParams
 	allOrdersByCreator, err := api.GetOrdersByCreatorAddress(ctx, GetOrdersByCreatorAddressParams{
 		CreatorAddress: order.OrderMaker,
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	// Filter through the second set of orders to find the signature
 	for _, o := range allOrdersByCreator {

--- a/sdk-clients/orderbook/api.go
+++ b/sdk-clients/orderbook/api.go
@@ -51,7 +51,7 @@ func (api *api) CreateOrder(ctx context.Context, params CreateOrderParams) (*Cre
 // TODO Reusing the same request/response objects until the openapi spec is updated to include the correct object definitions
 
 // GetOrdersByCreatorAddress returns all orders created by a given address in the Limit Order Protocol
-func (api *api) GetOrdersByCreatorAddress(ctx context.Context, params GetOrdersByCreatorAddressParams) ([]OrderResponse, error) {
+func (api *api) GetOrdersByCreatorAddress(ctx context.Context, params GetOrdersByCreatorAddressParams) ([]*OrderResponse, error) {
 	u := fmt.Sprintf("/orderbook/v4.0/%d/address/%s", api.chainId, params.CreatorAddress)
 
 	err := params.Validate()
@@ -65,7 +65,7 @@ func (api *api) GetOrdersByCreatorAddress(ctx context.Context, params GetOrdersB
 		U:      u,
 	}
 
-	var ordersResponse []OrderResponse
+	var ordersResponse []*OrderResponse
 	err = api.httpExecutor.ExecuteRequest(ctx, payload, &ordersResponse)
 	if err != nil {
 		return nil, err

--- a/sdk-clients/orderbook/examples/create_and_fill_order/main.go
+++ b/sdk-clients/orderbook/examples/create_and_fill_order/main.go
@@ -88,6 +88,8 @@ func main() {
 		log.Fatalf("Request completed, but order creation status was a failure: %v\n", createOrderResponse)
 	}
 
+	fmt.Println("Order created! Getting order hash...")
+
 	// Sleep to accommodate free-tier API keys
 	time.Sleep(time.Second)
 
@@ -95,12 +97,20 @@ func main() {
 		CreatorAddress: client.Wallet.Address().Hex(),
 	})
 
-	fmt.Printf("Order created! \nOrder hash: %v\n", ordersByCreatorResponse[0].OrderHash)
+	fmt.Printf("Order hash: %v\n", ordersByCreatorResponse[0].OrderHash)
+	fmt.Println("Getting signature...")
 
 	// Sleep to accommodate free-tier API keys
 	time.Sleep(time.Second)
 
-	fillOrderData, err := client.GetFillOrderCalldata(ordersByCreatorResponse[0], nil)
+	orderWithSignature, err := client.GetOrderWithSignature(ctx, orderbook.GetOrderParams{
+		OrderHash:               ordersByCreatorResponse[0].OrderHash,
+		SleepBetweenSubrequests: true,
+	})
+
+	fmt.Println("Getting retrieved! Filling order...")
+
+	fillOrderData, err := client.GetFillOrderCalldata(orderWithSignature, nil)
 	if err != nil {
 		log.Fatalf("Failed to get fill order calldata: %v", err)
 	}

--- a/sdk-clients/orderbook/examples/create_and_fill_order/main.go
+++ b/sdk-clients/orderbook/examples/create_and_fill_order/main.go
@@ -91,20 +91,19 @@ func main() {
 	// Sleep to accommodate free-tier API keys
 	time.Sleep(time.Second)
 
-	getOrderResponse, err := client.GetOrdersByCreatorAddress(ctx, orderbook.GetOrdersByCreatorAddressParams{
+	ordersByCreatorResponse, err := client.GetOrdersByCreatorAddress(ctx, orderbook.GetOrdersByCreatorAddressParams{
 		CreatorAddress: client.Wallet.Address().Hex(),
 	})
 
-	fmt.Printf("Order created! \nOrder hash: %v\n", getOrderResponse[0].OrderHash)
+	fmt.Printf("Order created! \nOrder hash: %v\n", ordersByCreatorResponse[0].OrderHash)
 
 	// Sleep to accommodate free-tier API keys
 	time.Sleep(time.Second)
 
-	getOrderRresponse, err := client.GetOrder(ctx, orderbook.GetOrderParams{
-		OrderHash: getOrderResponse[0].OrderHash,
-	})
-
-	fillOrderData, err := client.GetFillOrderCalldata(getOrderRresponse, nil)
+	fillOrderData, err := client.GetFillOrderCalldata(ordersByCreatorResponse[0], nil)
+	if err != nil {
+		log.Fatalf("Failed to get fill order calldata: %v", err)
+	}
 
 	aggregationRouter, err := constants.Get1inchRouterFromChainId(chainId)
 	if err != nil {

--- a/sdk-clients/orderbook/examples/fill_order/main.go
+++ b/sdk-clients/orderbook/examples/fill_order/main.go
@@ -39,9 +39,11 @@ func main() {
 	}
 	client, err := orderbook.NewClient(config)
 
-	getOrderResponse, err := client.GetOrder(ctx, orderbook.GetOrderParams{
-		OrderHash: limitOrderHash,
-	})
+	params := orderbook.GetOrderParams{
+		OrderHash:               limitOrderHash,
+		SleepBetweenSubrequests: true,
+	}
+	getOrderResponse, err := client.GetOrderWithSignature(ctx, params)
 
 	takerTraits := orderbook.NewTakerTraits(orderbook.TakerTraitsParams{
 		Extension: getOrderResponse.Data.Extension,

--- a/sdk-clients/orderbook/normalization.go
+++ b/sdk-clients/orderbook/normalization.go
@@ -50,6 +50,48 @@ func NormalizeGetOrderByHashResponse(resp *GetOrderByHashResponse) (*GetOrderByH
 	}, nil
 }
 
+func NormalizeOrderResponse(resp *OrderResponse) (*OrderResponseExtended, error) {
+	saltBigInt, ok := new(big.Int).SetString(resp.Data.Salt, 10)
+	if !ok {
+		saltBigInt, ok = new(big.Int).SetString(resp.Data.Salt[2:], 16)
+		if !ok {
+			return nil, fmt.Errorf("invalid salt value")
+		}
+	}
+	makingAmountBigInt, ok := new(big.Int).SetString(resp.Data.MakingAmount, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid making amount value")
+	}
+	takingAmountBigInt, ok := new(big.Int).SetString(resp.Data.TakingAmount, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid taking amount value")
+	}
+
+	makerAssetBigInt := AddressStringToBigInt(resp.Data.MakerAsset)
+	takerAssetBigInt := AddressStringToBigInt(resp.Data.TakerAsset)
+	makerBigInt := AddressStringToBigInt(resp.Data.Maker)
+	receiverBigInt := AddressStringToBigInt(resp.Data.Receiver)
+
+	makerTraits, err := hexutil.DecodeBig(resp.Data.MakerTraits)
+	if err != nil {
+		return nil, fmt.Errorf("invalid maker traits value")
+	}
+
+	return &OrderResponseExtended{
+		OrderResponse: *resp,
+		LimitOrderDataNormalized: NormalizedLimitOrderData{
+			Salt:         saltBigInt,
+			MakerAsset:   makerAssetBigInt,
+			TakerAsset:   takerAssetBigInt,
+			Maker:        makerBigInt,
+			Receiver:     receiverBigInt,
+			MakingAmount: makingAmountBigInt,
+			TakingAmount: takingAmountBigInt,
+			MakerTraits:  makerTraits,
+		},
+	}, nil
+}
+
 func AddressStringToBigInt(addressString string) *big.Int {
 	address := common.HexToAddress(addressString)
 	addressBytes := new(big.Int).SetBytes(address.Bytes())

--- a/sdk-clients/orderbook/normalization.go
+++ b/sdk-clients/orderbook/normalization.go
@@ -50,48 +50,6 @@ func NormalizeGetOrderByHashResponse(resp *GetOrderByHashResponse) (*GetOrderByH
 	}, nil
 }
 
-func NormalizeOrderResponse(resp *OrderResponse) (*OrderResponseExtended, error) {
-	saltBigInt, ok := new(big.Int).SetString(resp.Data.Salt, 10)
-	if !ok {
-		saltBigInt, ok = new(big.Int).SetString(resp.Data.Salt[2:], 16)
-		if !ok {
-			return nil, fmt.Errorf("invalid salt value")
-		}
-	}
-	makingAmountBigInt, ok := new(big.Int).SetString(resp.Data.MakingAmount, 10)
-	if !ok {
-		return nil, fmt.Errorf("invalid making amount value")
-	}
-	takingAmountBigInt, ok := new(big.Int).SetString(resp.Data.TakingAmount, 10)
-	if !ok {
-		return nil, fmt.Errorf("invalid taking amount value")
-	}
-
-	makerAssetBigInt := AddressStringToBigInt(resp.Data.MakerAsset)
-	takerAssetBigInt := AddressStringToBigInt(resp.Data.TakerAsset)
-	makerBigInt := AddressStringToBigInt(resp.Data.Maker)
-	receiverBigInt := AddressStringToBigInt(resp.Data.Receiver)
-
-	makerTraits, err := hexutil.DecodeBig(resp.Data.MakerTraits)
-	if err != nil {
-		return nil, fmt.Errorf("invalid maker traits value")
-	}
-
-	return &OrderResponseExtended{
-		OrderResponse: *resp,
-		LimitOrderDataNormalized: NormalizedLimitOrderData{
-			Salt:         saltBigInt,
-			MakerAsset:   makerAssetBigInt,
-			TakerAsset:   takerAssetBigInt,
-			Maker:        makerBigInt,
-			Receiver:     receiverBigInt,
-			MakingAmount: makingAmountBigInt,
-			TakingAmount: takingAmountBigInt,
-			MakerTraits:  makerTraits,
-		},
-	}, nil
-}
-
 func AddressStringToBigInt(addressString string) *big.Int {
 	address := common.HexToAddress(addressString)
 	addressBytes := new(big.Int).SetBytes(address.Bytes())

--- a/sdk-clients/orderbook/orderbook_types_manual.go
+++ b/sdk-clients/orderbook/orderbook_types_manual.go
@@ -92,6 +92,11 @@ type OrderResponse struct {
 	OrderInvalidReason   interface{} `json:"orderInvalidReason"`
 }
 
+type OrderResponseExtended struct {
+	OrderResponse
+	LimitOrderDataNormalized NormalizedLimitOrderData
+}
+
 type GetOrderByHashResponse struct {
 	ID                   int         `json:"id"`
 	OrderHash            string      `json:"orderHash"`
@@ -101,7 +106,6 @@ type GetOrderByHashResponse struct {
 	MakerAsset           string      `json:"makerAsset"`
 	OrderMaker           string      `json:"orderMaker"`
 	OrderStatus          int         `json:"orderStatus"`
-	Signature            string      `json:"signature"`
 	MakerAmount          string      `json:"makerAmount"`
 	RemainingMakerAmount string      `json:"remainingMakerAmount"`
 	MakerBalance         string      `json:"makerBalance"`

--- a/sdk-clients/orderbook/orderbook_types_manual.go
+++ b/sdk-clients/orderbook/orderbook_types_manual.go
@@ -31,7 +31,8 @@ type GetOrdersByCreatorAddressParams struct {
 }
 
 type GetOrderParams struct {
-	OrderHash string
+	OrderHash               string
+	SleepBetweenSubrequests bool // For free accounts, this should be set to true to avoid 429 errors when using the GetOrderWithSignature method
 }
 
 type GetAllOrdersParams struct {
@@ -142,6 +143,12 @@ type GetOrderByHashResponseExtended struct {
 	GetOrderByHashResponse
 
 	LimitOrderDataNormalized NormalizedLimitOrderData
+}
+
+type OrderExtendedWithSignature struct {
+	GetOrderByHashResponse
+	LimitOrderDataNormalized NormalizedLimitOrderData
+	Signature                string
 }
 
 type NormalizedLimitOrderData struct {

--- a/sdk-clients/orderbook/web3data.go
+++ b/sdk-clients/orderbook/web3data.go
@@ -39,15 +39,10 @@ func (c *Client) GetSeriesNonce(ctx context.Context, publicAddress gethCommon.Ad
 	return nonce, nil
 }
 
-func (c *Client) GetFillOrderCalldata(orderResponse *OrderResponse, takerTraits *TakerTraits) ([]byte, error) {
-
-	orderResponseExtended, err := NormalizeOrderResponse(orderResponse)
-	if err != nil {
-		return nil, err
-	}
+func (c *Client) GetFillOrderCalldata(order *OrderExtendedWithSignature, takerTraits *TakerTraits) ([]byte, error) {
 
 	var function string
-	if orderResponseExtended.Data.Extension == "0x" {
+	if order.Data.Extension == "0x" {
 		function = "fillOrder"
 	} else {
 		if takerTraits == nil {
@@ -57,7 +52,7 @@ func (c *Client) GetFillOrderCalldata(orderResponse *OrderResponse, takerTraits 
 		function = "fillOrderArgs"
 	}
 
-	compressedSignature, err := CompressSignature(orderResponseExtended.Signature[2:])
+	compressedSignature, err := CompressSignature(order.Signature[2:])
 	if err != nil {
 		return nil, err
 	}
@@ -76,13 +71,13 @@ func (c *Client) GetFillOrderCalldata(orderResponse *OrderResponse, takerTraits 
 
 	switch function {
 	case "fillOrder":
-		fillOrderData, err = c.AggregationRouterV6.Pack(function, orderResponseExtended.LimitOrderDataNormalized, rCompressed, vsCompressed, orderResponseExtended.LimitOrderDataNormalized.TakingAmount, big.NewInt(0))
+		fillOrderData, err = c.AggregationRouterV6.Pack(function, order.LimitOrderDataNormalized, rCompressed, vsCompressed, order.LimitOrderDataNormalized.TakingAmount, big.NewInt(0))
 		if err != nil {
 			return nil, err
 		}
 	case "fillOrderArgs":
 		takerTraitsEncoded := takerTraits.Encode()
-		fillOrderData, err = c.AggregationRouterV6.Pack(function, orderResponseExtended.LimitOrderDataNormalized, rCompressed, vsCompressed, orderResponseExtended.LimitOrderDataNormalized.TakingAmount, takerTraitsEncoded.TraitFlags, takerTraitsEncoded.Args)
+		fillOrderData, err = c.AggregationRouterV6.Pack(function, order.LimitOrderDataNormalized, rCompressed, vsCompressed, order.LimitOrderDataNormalized.TakingAmount, takerTraitsEncoded.TraitFlags, takerTraitsEncoded.Args)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Signatures have been removed from the order lookup endpoint, so now they must be found from the maker endpoint.