### PR TITLE
ci: fix release workflow to compute semver tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,15 @@ on:
     inputs:
       version:
         type: choice
-        description: Version
+        description: Semantic version bump to apply to the latest release tag
         options:
           - patch
           - minor
           - major
           - prerelease
+
+permissions:
+  contents: write
 
 jobs:
   create:
@@ -19,22 +22,77 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21.0'
+          go-version: '1.25'
 
       - name: Build
         run: go build -v ./...
 
+      - name: Compute next version
+        id: version
+        run: |
+          set -euo pipefail
+          bump="${{ github.event.inputs.version }}"
+
+          # Base every bump on the latest stable release tag (ignore pre-releases).
+          latest_stable=$(git tag -l 'v*' --sort=-v:refname | grep -vE '\-' | head -n1 || true)
+          latest_stable="${latest_stable:-v0.0.0}"
+          echo "Latest stable tag: $latest_stable"
+
+          core="${latest_stable#v}"
+          IFS='.' read -r major minor patch <<< "$core"
+
+          case "$bump" in
+            major)
+              next="v$((major + 1)).0.0"
+              ;;
+            minor)
+              next="v${major}.$((minor + 1)).0"
+              ;;
+            patch)
+              next="v${major}.${minor}.$((patch + 1))"
+              ;;
+            prerelease)
+              rc_core="v${major}.${minor}.$((patch + 1))"
+              last_rc=$(git tag -l "${rc_core}-rc.*" --sort=-v:refname | head -n1 || true)
+              if [ -n "$last_rc" ]; then
+                n="${last_rc##*-rc.}"
+                next="${rc_core}-rc.$((n + 1))"
+              else
+                next="${rc_core}-rc.1"
+              fi
+              ;;
+            *)
+              echo "Unknown bump type: $bump" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "Next version: $next"
+          if git rev-parse "$next" >/dev/null 2>&1; then
+            echo "Tag $next already exists" >&2
+            exit 1
+          fi
+
+          echo "version=$next" >> "$GITHUB_OUTPUT"
+          if [[ "$next" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.event.inputs.version }}
-          release_name: Release ${{ github.event.inputs.version }}
-          draft: false
-          prerelease: false
+        run: |
+          set -euo pipefail
+          args=(--target "$GITHUB_SHA" --title "${{ steps.version.outputs.version }}" --generate-notes)
+          if [ "${{ steps.version.outputs.prerelease }}" = "true" ]; then
+            args+=(--prerelease)
+          fi
+          gh release create "${{ steps.version.outputs.version }}" "${args[@]}"


### PR DESCRIPTION
## Summary

The `Release new version` workflow was broken and could not produce a valid release:

- It tagged with `tag_name: ${{ github.event.inputs.version }}`, so a dispatch would create a git tag literally named `patch` / `minor` / `major` / `prerelease` instead of a semver version.
- It pinned Go `1.21.0` (now below the module's minimum of 1.25).
- It used the archived `actions/create-release@v1` action.

This PR rewrites it to:

- **Compute the next version** from the latest stable release tag based on the selected bump:
  - `major` → `v5.0.0`
  - `minor` → `v4.1.0`
  - `patch` → `v4.0.1`
  - `prerelease` → `v4.0.1-rc.1` (auto-increments the rc counter)
- Build with **Go 1.25** (`setup-go@v5`, `checkout@v4`, `fetch-depth: 0` for tag history).
- Create the release with the **`gh` CLI** (`--generate-notes`, `--prerelease` for pre-releases), and add `contents: write` permission.

Bump logic was verified locally against the current tags (latest `v4.0.0`) and produces the versions listed above. `actionlint` passes.

## Test plan

- [x] `actionlint .github/workflows/release.yml` passes
- [x] Version computation validated against real repo tags
- [ ] Dry-run via `workflow_dispatch` (e.g. select `prerelease`) after merge to confirm end-to-end tag/release creation