### PR TITLE
ci: bump checkout/setup-go in canary and integration workflows to match pr.yml

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code into workspace directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go 1.25
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.25'
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code into workspace directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go 1.25
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.25'
 


### PR DESCRIPTION
## What

Bump the GitHub Actions pins in `canary.yml` and `integration.yml` to the versions `pr.yml` already uses:

| | before | after |
|---|---|---|
| `actions/checkout` | `v3` | `v4` |
| `actions/setup-go` | `v3` | `v5` |

## Why

`pr.yml` — the workflow that runs on every pull request — is already on `actions/checkout@v4` and `actions/setup-go@v5`. The two scheduled workflows were left behind on `@v3`, which runs on the retired Node 16 action runtime, so the nightly and weekly runs emit deprecation warnings that the PR workflow does not.

`setup-go@v5` also matters a little more than a warning: the `v3` line predates the current Go toolchain handling, while these jobs ask for `go-version: '1.25'`. `pr.yml` already resolves that same version through `@v5`.

## Not included

- `foundry-rs/foundry-toolchain@v1` in `integration.yml` is untouched — `v1` is that action's current major, not a stale pin.
- The last two scheduled `Production canary` runs (2026-08-03, 2026-08-10) failed at the `Place and monitor dust-sized canary trades` step. That is unrelated to the action versions and this PR does not attempt to address it — flagging it only so the failure is not mistaken for a regression from this change.

## Verification

Both files parse as YAML, job names and step inputs are unchanged, and each target major (`checkout@v4`, `setup-go@v5`) exists upstream.
